### PR TITLE
Fixed 3 issues of type: PYTHON_E225 throughout 3 files in repo.

### DIFF
--- a/ls/joyous/formats/google.py
+++ b/ls/joyous/formats/google.py
@@ -89,7 +89,7 @@ class RecurringGEvent(GEvent):
         gevent.set('dates', vPeriod((dtstart, dtend)).to_ical().decode())
         if page.tz != pytz.utc:
             gevent.set('ctz', page.tz.zone)
-        gevent.set('recur', "RRULE:"+ page.repeat._getRrule())
+        gevent.set('recur', "RRULE:" + page.repeat._getRrule())
         # TODO: try and confirm...
         # Google doesn't accept EXDATE or RDATE here :-(
         return gevent

--- a/ls/joyous/models/events.py
+++ b/ls/joyous/models/events.py
@@ -1719,7 +1719,7 @@ class RescheduleMultidayEventPage(ProxyPageMixin, PostponementPage):
 
     postponement_panel = MultiFieldPanel(
             PostponementPage.postponement_panel0 +
-            [FieldPanel('num_days')]+
+            [FieldPanel('num_days')] +
             PostponementPage.postponement_panel1,
             heading=_("Postponed to"))
     content_panels = [

--- a/shell.py
+++ b/shell.py
@@ -22,7 +22,7 @@ elif __name__ == "builtins":
     from ls.joyous.utils.recurrence import *
     from ls.joyous.utils import manythings, telltime
     from ls.joyous.formats import ical
-    L=list
+    L = list
     sys.displayhook = pprint.pprint
     sys.__interactivehook__()
     timezone.activate("Pacific/Auckland")


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.