### PR TITLE
Use max_count to restrict CalendarPage creation

### DIFF
--- a/ls/joyous/formats/ical.py
+++ b/ls/joyous/formats/ical.py
@@ -11,7 +11,7 @@ import quopri
 from icalendar import Calendar, Event
 from icalendar import vDatetime, vRecur, vDDDTypes, vText
 from django.contrib import messages
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import HttpResponse
 from django.utils import timezone
 from ls.joyous import __version__
@@ -178,11 +178,13 @@ class VCalendar(Calendar, VComponentMixin):
             if vevent is not None:
                 try:
                     event = self.page._getEventFromUid(request, vevent['UID'])
+                except PermissionDenied:
+                    # No authority
+                    pass
                 except ObjectDoesNotExist:
                     numSuccess += self._createEventPage(request, vevent)
                 else:
-                    if event:
-                        numSuccess += self._updateEventPage(request, vevent, event)
+                    numSuccess += self._updateEventPage(request, vevent, event)
         return numSuccess, numFail
 
     def _updateEventPage(self, request, vevent, event):

--- a/ls/joyous/models/calendar.py
+++ b/ls/joyous/models/calendar.py
@@ -112,6 +112,8 @@ EVENTS_VIEW_CHOICES = [('L', _("List View")),
 # ------------------------------------------------------------------------------
 class CalendarPage(RoutablePageMixin, Page):
     """CalendarPage displays all the events which are in the same site."""
+    max_count = 1
+
     class Meta:
         verbose_name = _("calendar page")
         verbose_name_plural = _("calendar pages")
@@ -491,6 +493,8 @@ class SpecificCalendarPage(ProxyPageMixin, CalendarPage):
     """
     SpecificCalendarPage displays only the events which are its children
     """
+    max_count = None
+
     class Meta(ProxyPageMixin.Meta):
         verbose_name = _("specific calendar page")
         verbose_name_plural = _("specific calendar pages")

--- a/ls/joyous/models/calendar.py
+++ b/ls/joyous/models/calendar.py
@@ -475,7 +475,7 @@ class CalendarPage(RoutablePageMixin, Page):
 
     def _getEventFromUid(self, request, uid):
         """Try and find an event with the given UID in this site."""
-        event = getEventFromUid(request, uid) # might raise ObjectDoesNotExist
+        event = getEventFromUid(request, uid) # might raise exception
         home = request.site.root_page
         if event.get_ancestors().filter(id=home.id).exists():
             # only return event if it is in the same site
@@ -526,7 +526,7 @@ class SpecificCalendarPage(ProxyPageMixin, CalendarPage):
 
     def _getEventFromUid(self, request, uid):
         """Try and find a child event with the given UID."""
-        event = getEventFromUid(request, uid)
+        event = getEventFromUid(request, uid) # might raise exception
         if event.get_ancestors().filter(id=self.id).exists():
             # only return event if it is a descendant
             return event
@@ -575,7 +575,7 @@ class GeneralCalendarPage(ProxyPageMixin, CalendarPage):
 
     def _getEventFromUid(self, request, uid):
         """Try and find an event with the given UID."""
-        return getEventFromUid(request, uid)
+        return getEventFromUid(request, uid) # might raise exception
 
     def _getAllEvents(self, request):
         """Return all the events."""

--- a/ls/joyous/models/events.py
+++ b/ls/joyous/models/events.py
@@ -10,7 +10,7 @@ from itertools import chain, groupby
 from operator import attrgetter
 from uuid import uuid4
 from django.conf import settings
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, PermissionDenied
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from django.db.models import Q
@@ -168,8 +168,8 @@ def getAllPastEvents(request, *, home=None):
 def getEventFromUid(request, uid):
     """
     Get the event by its UID
-    (returns None if we have no authority, raises ObjectDoesNotExist if it is
-    not found).
+    (raises PermissionDenied if we have no authority, ObjectDoesNotExist if it
+    is not found).
 
     :param request: Django request object
     :param uid: iCal unique identifier
@@ -188,7 +188,7 @@ def getEventFromUid(request, uid):
         if events[0].isAuthorized(request):
             return events[0]
         else:
-            return None
+            raise PermissionDenied("No authority for uid={}".format(uid))
     elif len(events) == 0:
         raise ObjectDoesNotExist("No event with uid={}".format(uid))
     else:

--- a/ls/joyous/tests/test_getevents.py
+++ b/ls/joyous/tests/test_getevents.py
@@ -7,7 +7,8 @@ import pytz
 import calendar
 from django.test import RequestFactory, TestCase
 from django.contrib.auth.models import User, AnonymousUser, Group
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import (MultipleObjectsReturned, ObjectDoesNotExist,
+                                    PermissionDenied)
 from django.utils import timezone
 from wagtail.core.models import Site, Page, PageViewRestriction
 from ls.joyous.utils.recurrence import Recurrence
@@ -234,8 +235,8 @@ class Test(TestCase):
             getEventFromUid(self.request, "d12971fb-e694-4a04-aba2-fb1a4a7166b9")
 
     def testAuthGetEventFromUid(self):
-        event = getEventFromUid(self.request, "80af64e7-84e6-40d9-8b4f-7edf92aab9f7")
-        self.assertIsNone(event)
+        with self.assertRaises(PermissionDenied):
+            event = getEventFromUid(self.request, "80af64e7-84e6-40d9-8b4f-7edf92aab9f7")
         self.request.user.groups.set([self.friends])
         event = getEventFromUid(self.request, "80af64e7-84e6-40d9-8b4f-7edf92aab9f7")
         self.assertIsNotNone(event.title)


### PR DESCRIPTION
> There can only be one CalendarPage per Wagtail site, so if you wish to repeat step 5 you will have to delete this one first.

The above note reminded me about the `max_count` attribute introduced in Wagtail 2.4

https://docs.wagtail.io/en/v2.5/reference/pages/model_reference.html#wagtail.core.models.Page.max_count