### PR TITLE
Rename EventBase.status to EventBase.event_status,

### DIFF
--- a/ls/joyous/models/event_base.py
+++ b/ls/joyous/models/event_base.py
@@ -357,7 +357,7 @@ class EventBase(models.Model):
         return self._getFromDt()
 
     @property
-    def status(self):
+    def event_status(self):
         """
         The current status of the event (started, finished or pending).
         """
@@ -372,7 +372,7 @@ class EventBase(models.Model):
         """
         A text description of the current status of the event.
         """
-        status = self.status
+        status = self.event_status
         if status == "finished":
             return _("This event has finished.")
         elif status == "started":

--- a/ls/joyous/models/recurring_events.py
+++ b/ls/joyous/models/recurring_events.py
@@ -330,7 +330,7 @@ class RecurringEventPage(EventBase, Page):
         return myFromDt.astimezone(localTZ)
 
     @property
-    def status(self):
+    def event_status(self):
         """
         The current status of the event (started, finished or pending).
         """
@@ -363,7 +363,7 @@ class RecurringEventPage(EventBase, Page):
         """
         A text description of the current status of the event.
         """
-        status = self.status
+        status = self.event_status
         if status == "finished":
             return _("These events have finished.")
         else:
@@ -907,7 +907,7 @@ class ExtraInfoPage(DateExceptionBase, Page):
     details     = property(attrgetter("overrides.details"))
 
     @property
-    def status(self):
+    def event_status(self):
         """
         The current status of the event (started, finished or pending).
         """
@@ -922,7 +922,7 @@ class ExtraInfoPage(DateExceptionBase, Page):
         """
         A text description of the current status of the event.
         """
-        status = self.status
+        status = self.event_status
         if status == "finished":
             return _("This event has finished.")
         elif status == "started":

--- a/ls/joyous/templates/joyous/event_base.html
+++ b/ls/joyous/templates/joyous/event_base.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <div class="content joy-content">
-  {% block event_status %}{% if page.status %}<div class="joy-ev-status">
+  {% block event_status %}{% if page.event_status %}<div class="joy-ev-status">
     {{ page.status_text }}
   </div>{% endif %}{% endblock event_status %}
   {% block event_title %}

--- a/ls/joyous/tests/test_cancellation.py
+++ b/ls/joyous/tests/test_cancellation.py
@@ -109,7 +109,7 @@ class Test(TestCase):
         return restriction
 
     def testStatus(self):
-        self.assertEqual(self.cancellation.status, "cancelled")
+        self.assertEqual(self.cancellation.event_status, "cancelled")
         self.assertEqual(self.cancellation.status_text, "This event has been cancelled.")
         now = dt.datetime.now()
         myday = now.date() + dt.timedelta(1)
@@ -120,7 +120,7 @@ class Test(TestCase):
                                      cancellation_title   = "",
                                      cancellation_details = "")
         self.event.add_child(instance=futureCan)
-        self.assertEqual(futureCan.status, "cancelled")
+        self.assertEqual(futureCan.event_status, "cancelled")
         self.assertEqual(futureCan.status_text, "This event has been cancelled.")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_closed_for_holidays.py
+++ b/ls/joyous/tests/test_closed_for_holidays.py
@@ -225,7 +225,7 @@ class Test(TestCase):
         self.assertIs(closedHols._closedOn(dt.date(1989, 3, 24)), False)
 
     def testStatus(self):
-        self.assertEqual(self.closedHols.status, "cancelled")
+        self.assertEqual(self.closedHols.event_status, "cancelled")
         self.assertEqual(self.closedHols.status_text, "Closed for holidays.")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_ext_cancellation.py
+++ b/ls/joyous/tests/test_ext_cancellation.py
@@ -197,7 +197,7 @@ class Test(TestCase):
         self.assertIs(self.shutdown._closedOn(dt.date(2020, 6, 22)), False)
 
     def testStatus(self):
-        self.assertEqual(self.shutdown.status, "cancelled")
+        self.assertEqual(self.shutdown.event_status, "cancelled")
         self.assertEqual(self.shutdown.status_text, "This event has been cancelled.")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_extra_info.py
+++ b/ls/joyous/tests/test_extra_info.py
@@ -55,7 +55,7 @@ class Test(TestCase):
         self.assertIs(type(page), ExtraInfoPage)
 
     def testStatus(self):
-        self.assertEqual(self.info.status, "finished")
+        self.assertEqual(self.info.event_status, "finished")
         self.assertEqual(self.info.status_text, "This event has finished.")
         now = timezone.localtime()
         myday = now.date() + dt.timedelta(days=1)
@@ -66,12 +66,12 @@ class Test(TestCase):
                                    extra_title = "It's Friday",
                                    extra_information = "Special")
         self.event.add_child(instance=futureInfo)
-        self.assertIsNone(futureInfo.status)
+        self.assertIsNone(futureInfo.event_status)
         self.assertEqual(futureInfo.status_text, "")
 
     @freeze_timetz("1988-11-11 14:00:00")
     def testStatusStarted(self):
-        self.assertEqual(self.info.status, "started")
+        self.assertEqual(self.info.event_status, "started")
         self.assertEqual(self.info.status_text, "This event has started.")
 
     def testWhen(self):
@@ -137,12 +137,12 @@ class TestMultiday(TestCase):
         self.info.save_revision().publish()
 
     def testStatusFinished(self):
-        self.assertEqual(self.info.status, "finished")
+        self.assertEqual(self.info.event_status, "finished")
         self.assertEqual(self.info.status_text, "This event has finished.")
 
     @freeze_timetz("2018-02-13 14:00:00")
     def testStatusStarted(self):
-        self.assertEqual(self.info.status, "started")
+        self.assertEqual(self.info.event_status, "started")
         self.assertEqual(self.info.status_text, "This event has started.")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_multiday_event.py
+++ b/ls/joyous/tests/test_multiday_event.py
@@ -52,7 +52,7 @@ class Test(TestCase):
         self.assertEqual(len(evod.continuing_events), 1)
 
     def testStatus(self):
-        self.assertEqual(self.event.status, "finished")
+        self.assertEqual(self.event.event_status, "finished")
         self.assertEqual(self.event.status_text, "This event has finished.")
         today = timezone.localdate()
         yesterday = today - dt.timedelta(1)
@@ -63,7 +63,7 @@ class Test(TestCase):
                                      date_from = yesterday,
                                      date_to   = nextWeek)
         self.calendar.add_child(instance=nowEvent)
-        self.assertEqual(nowEvent.status, "started")
+        self.assertEqual(nowEvent.event_status, "started")
         self.assertEqual(nowEvent.status_text, "This event has started.")
         tomorrow = today + dt.timedelta(days=1)
         futureEvent = MultidayEventPage(owner = self.user,
@@ -72,7 +72,7 @@ class Test(TestCase):
                                         date_from  = tomorrow,
                                         date_to    = tomorrow + dt.timedelta(days=1))
         self.calendar.add_child(instance=futureEvent)
-        self.assertIsNone(futureEvent.status)
+        self.assertIsNone(futureEvent.event_status)
         self.assertEqual(futureEvent.status_text, "")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_postponement.py
+++ b/ls/joyous/tests/test_postponement.py
@@ -76,7 +76,7 @@ class Test(TestCase):
         self.assertIs(type(page), PostponementPage)
 
     def testStatus(self):
-        self.assertEqual(self.postponement.status, "finished")
+        self.assertEqual(self.postponement.event_status, "finished")
         self.assertEqual(self.postponement.status_text, "This event has finished.")
         now = timezone.localtime()
         myday = now.date() + dt.timedelta(1)
@@ -92,12 +92,12 @@ class Test(TestCase):
                                        time_to   = dt.time(16),
                                        details   = "The meeting postponed from last Friday")
         self.event.add_child(instance=futureEvent)
-        self.assertIsNone(futureEvent.status)
+        self.assertIsNone(futureEvent.event_status)
         self.assertEqual(futureEvent.status_text, "")
 
     @freeze_timetz("1990-10-11 16:29:00")
     def testStatusStarted(self):
-        self.assertEqual(self.postponement.status, "started")
+        self.assertEqual(self.postponement.event_status, "started")
         self.assertEqual(self.postponement.status_text, "This event has started.")
 
     def testWhen(self):

--- a/ls/joyous/tests/test_recurring_event.py
+++ b/ls/joyous/tests/test_recurring_event.py
@@ -59,7 +59,7 @@ class Test(TestCase):
                                                            freq=WEEKLY,
                                                            byweekday=[SA,SU]))
         self.calendar.add_child(instance=pastEvent)
-        self.assertEqual(pastEvent.status, "finished")
+        self.assertEqual(pastEvent.event_status, "finished")
         self.assertEqual(pastEvent.status_text, "These events have finished.")
         now = timezone.localtime()
         earlier = now - dt.timedelta(hours=1)
@@ -73,7 +73,7 @@ class Test(TestCase):
                                       time_from = earlier.time(),
                                       time_to   = dt.time.max)
         self.calendar.add_child(instance=nowEvent)
-        self.assertEqual(nowEvent.status, "started")
+        self.assertEqual(nowEvent.event_status, "started")
         self.assertEqual(nowEvent.status_text, "This event has started.")
         today = timezone.localdate()
         notToday = [weekday for weekday in EVERYWEEKDAY if weekday.weekday != today.weekday()]
@@ -84,7 +84,7 @@ class Test(TestCase):
                                                                     freq=WEEKLY,
                                                                     byweekday=notToday))
         self.calendar.add_child(instance=pastAndFutureEvent)
-        self.assertIsNone(pastAndFutureEvent.status)
+        self.assertIsNone(pastAndFutureEvent.event_status)
         self.assertEqual(pastAndFutureEvent.status_text, "")
 
     @freeze_timetz("2008-05-04 09:01")
@@ -99,7 +99,7 @@ class Test(TestCase):
                                       time_from = dt.time(8),
                                       time_to   = dt.time(9))
         self.calendar.add_child(instance=event)
-        self.assertEqual(event.status, "finished")
+        self.assertEqual(event.event_status, "finished")
 
     @freeze_timetz("2008-05-04 07:00")
     def testLastOccurenceCancelledStatus(self):
@@ -119,7 +119,7 @@ class Test(TestCase):
                                         cancellation_title   = "Fire in the kitchen",
                                         cancellation_details = "The bacon fat is burning")
         event.add_child(instance=cancellation)
-        self.assertEqual(event.status, "finished")
+        self.assertEqual(event.event_status, "finished")
 
     @freeze_timetz("2008-05-04 12:00")
     def testPostponementOccurenceLast(self):
@@ -144,7 +144,7 @@ class Test(TestCase):
                                         time_from = dt.time(8),
                                         time_to   = dt.time(9))
         event.add_child(instance=postponement)
-        self.assertIsNone(event.status)
+        self.assertIsNone(event.event_status)
         self.assertEqual(event._nextOn(request),
                          '<a class="inline-link" href="/events/breakfast3/2008-05-03-postponement/">Saturday 24th of May at 8am</a>')
 

--- a/ls/joyous/tests/test_reschedule_multiday_event.py
+++ b/ls/joyous/tests/test_reschedule_multiday_event.py
@@ -56,7 +56,7 @@ class Test(TestCase):
 
     @freeze_timetz("1990-02-08 16:00")
     def testEventStatus(self):
-        self.assertEqual(self.event.status, "started")
+        self.assertEqual(self.event.event_status, "started")
         postponement = RescheduleMultidayEventPage(owner = self.user,
                                              overrides = self.event,
                                              except_date = dt.date(1990,2,6),
@@ -67,7 +67,7 @@ class Test(TestCase):
                                              time_to   = dt.time(16,30))
         self.event.add_child(instance=postponement)
         postponement.save_revision().publish()
-        self.assertIsNone(self.event.status)
+        self.assertIsNone(self.event.event_status)
 
     def testRemoveContentPanels(self):
         RescheduleMultidayEventPage._removeContentPanels(["tz", "location"])
@@ -80,7 +80,7 @@ class Test(TestCase):
 
     @freeze_timetz("1990-01-11 18:00")
     def testStatus(self):
-        self.assertEqual(self.postponement.status, "started")
+        self.assertEqual(self.postponement.event_status, "started")
         self.assertEqual(self.postponement.status_text, "This event has started.")
 
     def testAt(self):

--- a/ls/joyous/tests/test_simple_event.py
+++ b/ls/joyous/tests/test_simple_event.py
@@ -45,7 +45,7 @@ class Test(TestCase):
         self.assertEqual(len(evod.continuing_events), 0)
 
     def testStatus(self):
-        self.assertEqual(self.event.status, "finished")
+        self.assertEqual(self.event.event_status, "finished")
         self.assertEqual(self.event.status_text, "This event has finished.")
         now = timezone.localtime()
         earlier = now - dt.timedelta(hours=1)
@@ -57,7 +57,7 @@ class Test(TestCase):
                                    date      = now.date(),
                                    time_from = earlier.time(),
                                    time_to   = dt.time.max)
-        self.assertEqual(nowEvent.status, "started")
+        self.assertEqual(nowEvent.event_status, "started")
         self.assertEqual(nowEvent.status_text, "This event has started.")
         tomorrow = timezone.localdate() + dt.timedelta(days=1)
         futureEvent = SimpleEventPage(owner = self.user,
@@ -65,7 +65,7 @@ class Test(TestCase):
                                       title = "Tomorrow's Event",
                                       date  = tomorrow)
         self.calendar.add_child(instance=futureEvent)
-        self.assertIsNone(futureEvent.status)
+        self.assertIsNone(futureEvent.event_status)
         self.assertEqual(futureEvent.status_text, "")
 
     def testWhen(self):


### PR DESCRIPTION
Event.status fieldname clashes with Django Model Utils Model.status field making subclasses of ls.joyous EventBase incompatible with any project that already implements Model Utils StatusField in their models.

This non-breaking change renames the EventBase.status property to EventBase.event_status and updates references to that field in templates and tests so that the clash no longer occurs.